### PR TITLE
docs: update example at readme(startTransition type)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,10 +50,11 @@ Using `useProgress` to show the `ProgressBar` when the [React transition](https:
 ```tsx
 // components/my-component.tsx
 "use client";
-import { useState, startTransition } from "react";
+import { useState, useTransition } from "react";
 import { useProgress } from "react-transition-progress";
 
 export default function MyComponent() {
+  const [_isPending, startTransition] = useTransition();
   const startProgress = useProgress();
   const [count, setCount] = useState(0);
   return (


### PR DESCRIPTION
Hello there. I love your works 👍 

BTW, I found some type issue at readme

```tsx
import { useState, startTransition } from "react";
// ...
startTransition(async () => { // type error at here
```

as you know `startTransition` does not accept asynchronous function

> https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6bd2d091d9978fe57807ae2ea1fd8ea87df6782a/types/react/index.d.ts#L2039-L2040

so I changed to your work at example

```tsx
import { useState, startTransition } from "react";

const [_isPending, startTransition] = useTransition();
// ...
```

---

Thanks to your great work for environment!