### PR TITLE
fix: bail out when clicking with `meta` or `ctrl` modifier keys

### DIFF
--- a/src/next.tsx
+++ b/src/next.tsx
@@ -21,6 +21,7 @@ export function Link({
         <NextLink
             href={href}
             onClick={(e) => {
+                if (e.metaKey || e.ctrlKey) return;
                 e.preventDefault();
                 startTransition(() => {
                     startProgress()


### PR DESCRIPTION
The current implementation of the link component prevents the default behavior of opening a link in a new tab when doing `cmd+click` on Mac or `ctrl+click` on Windows. This PR restores this functionality.
