### PR TITLE
feat: add support for passing ref to Link

### DIFF
--- a/src/next.tsx
+++ b/src/next.tsx
@@ -24,18 +24,19 @@ function isModifiedEvent(event: React.MouseEvent): boolean {
 /**
  * A custom Link component that wraps Next.js's next/link component.
  */
-export function Link({
+export const Link = React.forwardRef<HTMLAnchorElement, Parameters<typeof NextLink>[0]>(function Link({
     href,
     children,
     replace,
     scroll,
     ...rest
-}: Parameters<typeof NextLink>[0]) {
+}, ref) {
     const router = useRouter();
     const startProgress = useProgress()
 
     return (
         <NextLink
+            ref={ref}
             href={href}
             onClick={(e) => {
                 if (isModifiedEvent(e)) return;
@@ -55,4 +56,4 @@ export function Link({
             {children}
         </NextLink>
     );
-}
+})


### PR DESCRIPTION
I am using shadcn/ui and want to use this inside `SheetClose` from https://ui.shadcn.com/docs/components/sheet.

When passing `asChild` to `SheetClose` it passes a ref to the child.

`Link` in this repo does not handle ref but `Link` from `next/link` does. So replacing `Link` from `next/link` from the one in this repo breaks. This PR fixes that by wrapping `Link` from this repo in `React.forwardRef`.